### PR TITLE
Add random numbers primitive page

### DIFF
--- a/docs/getting-started/for-developers/develop-deploy-dapp.md
+++ b/docs/getting-started/for-developers/develop-deploy-dapp.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 # Develop & Deploy dApp
 
 ## 1. Develop Smart Contracts
-Smart contracts are the backbone of your dApp, defining its rules and operations. Begin your development in Solidity based on the instructions [here](/docs/getting-started/for-developers/explore-contracts-in-obscuro).
+Smart contracts are the backbone of your dApp, defining its rules and operations. Begin your development in Solidity based on the instructions [here](/docs/getting-started/for-developers/explore-contracts-in-ten).
 
 ## 2. Develop the Frontend
 Use common web tools like HTML, CSS, and JavaScript. You can consider ReactJs, VueJs to enhance development. To connect your frontend to Ethereum, choose a library such as Web3.js or Ether.js. See supported libraries [here](#).

--- a/docs/getting-started/for-developers/explore-contracts-in-ten.md
+++ b/docs/getting-started/for-developers/explore-contracts-in-ten.md
@@ -92,11 +92,12 @@ Ten nodes run on secure enclave's, ensuring:
 **Example**:
 ```solidity
 function getRandomNumber() public view returns (uint256) {
-    return uint256(blockhash(block.number - 1));
+    // Ten network injects a secure and unique seed to the prevrandao property, note: on other EVM chains this code would be exploitable by MEV bots
+    return uint256(block.prevrandao);
 }
 ```
 
-Ten's approach ensures secure and straightforward random number generation.
+Ten's approach ensures secure and straightforward random number generation. For more information on using randomness in Ten, take a look at the [Random Numbers page](/docs/standards-primitives/random-numbers.md).
 
 ## 5. Gas Consumption
 

--- a/docs/standards-primitives/random-numbers.md
+++ b/docs/standards-primitives/random-numbers.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+---
+
+# Random Numbers
+
+
+## Using Randomness on Ten
+
+Random numbers are available as a secure and private primitive within Ten contracts.
+
+A random string of bytes can be accessed in solidity contracts on Ten using `block.prevrandao`, just like on Ethereum mainnet. But it is important to stress that this provides **much stronger** security guarantees than those on mainnet.
+
+## Benefits of Ten Randomness
+On mainnet, `block.prevrandao` must be used with care, it has some important caveats:
+- The same random value is provided to every transaction executing in the ssame block.
+- The value is known at the time the transactions are being ordered into the block, meaning MEV bots can manipulate outcomes.
+
+The same code on Ten does not expose those attack vectors. It should be noted that:
+- A fresh, uncorrelated key is generated for each transaction.
+- The value cannot be seen outside of the executing code, secure enclave hardware means even node operators can't access it.
+- Outcomes cannot be known until the block is published (which cannot be undone), removing the threat of MEV exploits.
+
+The upshot of all this is that developers have much less to think about and secure contract code can stay simple and clean.
+
+Also, users will often have a better experience with dapps on Ten because Oracles and commit-reveal schemes that required artificial delays and extra transactions are no longer necessary.
+
+## Example
+
+This example is taken from a live app, the [Guessing Game demo application](../tutorials-examples/guessing-game.md).
+
+This solidity function is used to reset the secret number which players are guessing. It is called both when the contract is first deployed, and also after a player wins the game.
+
+It will set the `secretNumber` private state to an integer between 1 and MAX_GUESS. 
+
+```
+function _resetSecretNumber() private {
+   uint256 randomNumber = block.prevrandao;
+   secretNumber = (randomNumber % MAX_GUESS) + 1;
+}
+```
+
+Now the game is immediately available to play again, with a fair random seed that had no external (oracle) dependency and no enforced delay or commit-reveal transactions.
+
+:::warning
+Be aware that the random seed is the same for the entire transaction. That means if your contract was called from another contract, then both contracts would see the same random seed during that transaction. 
+
+In many cases this does not matter, the result of the dice roll or the lottery winner is immediately made public anyway, so there is no information to leak. But in some cases you may want to put a check in place to ensure that a longer-lived random secret cannot be leaked. For example, you may choose to require your contract can only be called directly, not from other contracts.
+
+This is important for situations (like the guessing game above) where the random seed must not revealed even **after** the transaction is completed.
+:::

--- a/docs/standards-primitives/random-numbers.md
+++ b/docs/standards-primitives/random-numbers.md
@@ -12,7 +12,7 @@ Random numbers are available as a secure and private primitive within Ten contra
 A random string of bytes can be accessed in solidity contracts on Ten using `block.prevrandao`, just like on Ethereum mainnet. But it is important to stress that this provides **much stronger** security guarantees than those on mainnet.
 
 ## Benefits of Ten Randomness
-On mainnet, `block.prevrandao` must be used with care, it has some important caveats:
+On Ethereum mainnet, `block.prevrandao` must be used with care. It has some important caveats:
 - The same random value is provided to every transaction executing in the ssame block.
 - The value is known at the time the transactions are being ordered into the block, meaning MEV bots can manipulate outcomes.
 
@@ -23,7 +23,7 @@ The same code on Ten does not expose those attack vectors. It should be noted th
 
 The upshot of all this is that developers have much less to think about and secure contract code can stay simple and clean.
 
-Also, users will often have a better experience with dapps on Ten because Oracles and commit-reveal schemes that required artificial delays and extra transactions are no longer necessary.
+Users also benefit, dapps using randomness on Ten can provide a much better UX because Oracles and commit-reveal schemes (which add artificial delays and extra transactions) are no longer necessary.
 
 ## Example
 

--- a/docs/standards-primitives/random-numbers.md
+++ b/docs/standards-primitives/random-numbers.md
@@ -13,7 +13,7 @@ A random string of bytes can be accessed in solidity contracts on Ten using `blo
 
 ## Benefits of Ten Randomness
 On Ethereum mainnet, `block.prevrandao` must be used with care. It has some important caveats:
-- The same random value is provided to every transaction executing in the ssame block.
+- The same random value is provided to every transaction executing in the same block.
 - The value is known at the time the transactions are being ordered into the block, meaning MEV bots can manipulate outcomes.
 
 The same code on Ten does not expose those attack vectors. It should be noted that:
@@ -23,7 +23,7 @@ The same code on Ten does not expose those attack vectors. It should be noted th
 
 The upshot of all this is that developers have much less to think about and secure contract code can stay simple and clean.
 
-Users also benefit, dapps using randomness on Ten can provide a much better UX because Oracles and commit-reveal schemes (which add artificial delays and extra transactions) are no longer necessary.
+Users also benefit, dApps using randomness on Ten can provide a much better UX because oracles and commit-reveal schemes (which add artificial delays and extra transactions) are no longer necessary.
 
 ## Example
 


### PR DESCRIPTION
Add page to explain random number usage on Ten. Also renamed a page that had Obscuro in name.

Screenshots:

![image](https://github.com/ten-protocol/ten-documentation/assets/98158711/474365b4-d516-401f-adc4-9a04bf6745a9)

![image](https://github.com/ten-protocol/ten-documentation/assets/98158711/059f4980-2f40-4101-9c54-ef60520afef0)
