### PR TITLE
Added governance content to docs

### DIFF
--- a/docs/governance/_category_.json
+++ b/docs/governance/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Governance",
+    "position": 10,
+    "link": {
+      "type": "generated-index"
+    }
+  }
+  

--- a/docs/governance/ten-network-association/_category_.json
+++ b/docs/governance/ten-network-association/_category_.json
@@ -1,0 +1,7 @@
+{
+    "label": "TEN Network Association",
+    "position": 1,
+    "link": {
+      "type": "generated-index"
+    }
+  }

--- a/docs/governance/ten-network-association/association.md
+++ b/docs/governance/ten-network-association/association.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 1
+---
+# About the TEN Network Association
+
+## Introduction and Vision
+
+### Mission Statement
+The TEN Network Association, the Association, aims to push forward the growth and development of the open-source TEN Network software protocol, building a lively and engaged community around it.
+
+### Purpose
+The Association is a not-for-profit organization based in Switzerland, dedicated to promoting, developing, and supporting the TEN software protocol and its ecosystem.  The Association’s goal is to tackle challenges within the Web3 space through decentralized governance and community-driven projects.
+
+## Governance and Structure
+
+### Legal Framework
+The Association operates as a Swiss Association governed by Swiss law. The legal foundation includes the Articles of Association, General Assembly Regulations, Organizational Regulations, and Governance Regulations.
+
+### Organizational Structure
+There are a number of bodies within the Association. New bodies can be created over time.
+1. **TEN Governance, or DAO**: participants in the TEN ecosystem who submit proposals for the advancement of TEN.
+1. **General Assembly**: the top decision-making body made up of all members.
+1. **Board**: manages and oversees the Association's operations.
+1. **Subcommittees**: created to handle specific tasks and projects, for example, the administration of grant programs.
+
+### Decision-Making Process
+Decisions are made through a combination of General Assembly votes and decentralized governance mechanisms using TEN tokens. Each token gives you one vote, and you can delegate your voting rights. You also need to hold the TEN tokens for at least 30 days. This prevents flash loan attacks.
+Responsible progress of TEN’s evolution is essential to its long term health and well being. If a proposal is voted in by the DAO but it would be bad for the mission of the TEN Network Association or if a law or regulation would be broken then the Board can step in to assist.
+
+## Projects and Initiatives
+### Ongoing Projects
+The Association supports a variety of projects aimed at improving TEN and its ecosystem, including software development, community-building, and educational initiatives. The Association also selects specific teams to help develop and enrich the TEN.
+
+### Proposals and Voting
+DAO members can submit proposals for new projects or changes to the protocol. Proposals are reviewed and voted on by participants in the TEN ecosystem.
+
+## Community and Communication
+### Communication Channels
+There are a number of communication channels dedicated to different purposes so all participants in the TEN ecosystem have an opportunity to engage widely with their fellow ecosystem participants.  
+
+The Association **[website](https://association.ten.xyz)** is the main hub for information and updates.  
+The Association **[forum](https://forum.ten.xyz)** is specifically focused on discussions on submitted improvement proposal. Improvement proposals will contain a link to the relevent discussion in the forum.  
+You can follow the Association on **[X](https://x.com/tenassociation)** for updates and the latest news.  
+
+### Community Guidelines
+We encourage respect, constructive feedback, and collaboration. We have clear guidelines and disciplinary actions for breaches.
+
+## Legal and Compliance Information
+### Legal Disclaimers
+Disclaimers are provided about the nature of the Association, risks involved, and legal obligations of members.
+
+### Compliance Information
+The Association adheres to Swiss laws and regulations, and compliance information is regularly updated and published.
+
+## Feedback and Improvement
+### Feedback Mechanisms
+Participants of the TEN ecosystem can provide feedback through the **[TEN Discord server](https://discord.gg/yQfmKeNzNd)**, occasional surveys, and direct communication using the contact details below.
+
+### Continuous Improvement
+Processes are in place for continuous improvement based on community feedback, ensuring the Association evolves and adapts to meet its goals effectively.
+
+The Association can be contacted by email: governance@ten.xyz
+
+The Association’s mailing address is:  
+TEN Network Association,  
+c/o MJP Partners AG,  
+Bahnhofstrasse 20,  
+6300 Zug  

--- a/docs/governance/ten-network-association/delegation.md
+++ b/docs/governance/ten-network-association/delegation.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 3
+---
+# Token Delegates and Delegating
+
+When you get involved in the governance of TEN, you can either vote directly on proposals or hand over your voting power to a delegate. The delegation system allows $TEN token holders to take part passively by transferring their voting power to delegates who share their values and who they trust to vote on their behalf in a way which aligns to those values. This page breaks down what delegates do and how delegation works within the governance of TEN.
+
+## What is a delegate?
+A delegate is someone in the TEN community chosen to represent other token holders and vote on their behalf. They are selected by token holders who decide to give their voting power to them. Delegates must stick to the rules set by TEN Network Association and act in the best interest of the token holders they represent.
+
+## Why delegate?
+Delegation is useful because it allows token holders to be part of the governance of TEN without having to follow every single proposal and vote. By delegating, token holders can let a representative vote on proposals in a way that matches their own views and values.  
+
+If you delegate your voting power, you can take it back whenever you want. You might want to do this if there's a proposal you feel strongly about and want to vote on directly.
+
+## How to delegate
+The governance of TEN uses Tally to make delegation easy:
+
+1. Connect your Ethereum wallet to Tally and go to the TEN governance page.
+2. Click on the "delegate" button.
+2. Find the delegate you want to give your voting power to and confirm the delegation by following the prompts on Tally.
+
+With Tally, you can change or cancel your delegation at any time. You can also split your voting power among multiple delegates.

--- a/docs/governance/ten-network-association/ten-token.md
+++ b/docs/governance/ten-network-association/ten-token.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+---
+# Overview of the TEN Token
+
+The TEN token, known as $TEN, is an ERC-20 governance token that lets you take part in the TEN’s on-chain decision-making process. The token is created by a smart contract on Ethereum, which is a secure and reliable decentralized blockchain.  
+
+With TEN's governance model, you get to manage both the governance rules laid out in the governance guidelines and the technologies it oversees through the submission of improvement proposals. If you hold TEN tokens you can vote on TEN improvement proposals (TIPs) which influence how TEN operates and evolves. For example, deciding on project grants, updating the validator whitelist for gated TEN networks, and deciding on bug bounties and ecosystem incentives.  
+
+When you vote on a TIP, you're using your TEN tokens to show whether you’re for or against it. The more TEN tokens you have, the more weight your vote carries. This is because the voting system, using smart contracts, is designed to be token-weighted, meaning your vote's power depends on how many tokens are in your wallet.  
+
+You can also delegate your TEN tokens to other wallets. So, you can vote with your tokens or someone else’s if they’ve given you their voting power. This is useful for folks who might not have time to go over proposals regularly. Just keep in mind, you need to have held your TEN tokens for at least 30 days before you can use them to vote. This helps prevent any quick, manipulative flash-loan attacks.  
+
+To summarize, the TEN token is a special digital asset that gives you the power to vote on proposals that impact how TEN is governed and the technology it controls. By holding TEN tokens, you get to help shape the future of the TEN ecosystem along with other like-minded participants.

--- a/docs/governance/ten-network-association/tip.md
+++ b/docs/governance/ten-network-association/tip.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 4
+---
+# TEN Improvement Proposals (TIP)
+
+A TEN Improvement Proposal (TIP) is an essential component of the governance of TEN because it is how participants in the TEN community can have an active role in the evolution of TEN.  
+
+TIPs are submitted by anyone holding TEN tokens and who are therefore members of the TEN Governance, or DAO. TIPs are used to modify procedures, install or modify software, update permission whitelists where they exist. Also TIPs include requests for funds or grants and provide guidelines or information to the community.
+
+## TIP Structure
+The following sections should be completed when creating a TIP to make them transparent, structured and easy to understand. The structure of a TIP follows the SMARTKIT approach:
+
+1. **Summary**: A brief summary of the TIP.
+1. **Motivation**: Justification for implementing the TIP.
+1. **Alignment**: Explanation of how the TIP aligns with TEN's mission and values.
+1. **Risks**: description of any risks of proceeding with the TIP.
+1. **Terms**: Definitions of unique, new, or industry-specific terms (optional).
+1. **Key Details**: Detailed breakdown of platforms, technologies, and design decisions. Includes alternate designs and related work.
+1. **Implementation**: Steps to implement the TIP, including assumptions, resources, type of expertise required and costs breakdown. Legal documentation should be included if relevant. 
+1. **Timing**: Start date, milestones, and completion dates.
+
+## Lifecycle of a TIP
+
+A TIP will go through several steps to help make sure as many members of the TEN community as possible can engage with and review the TIP. Progressing past each step represents levelling-up in the process. Timeframes for each step help encourage reviews to be done in a timely manner.
+
+| Level | Description                               | Timeframe | 
+|-------|-------------------------------------------|-----------|
+| 8 (End)     | ⭐ TIP Implementation               | Minutes  |
+| 7     | ⬆️ Ethereum Finalization Period           | 3 days   |
+| 6     | ⬆️ TEN to Ethereum Message                | 0.5 day  |
+| 5     | ⬆️ Reaction Period                        | 3 days   |
+| 4     | ⬆️ Acknowledge and Confirm                | 3 days   |
+| 3     | ⬆️ On-chain Vote                          | 14 days  |
+| 2     | ⬆️ On-chain Voting Preparation            | 3 days   |
+| 🛑    | Gate                                      |          |
+| 1 (Start)     | ⬆️ Interest Gathering, Off-chain Vote     | 14 days   |
+
+### Level 1: Interest Gathering, Off-chain Vote
+This first level is a preliminary filter to remove TIPs with low levels of interest or TIPs which will break the rules of the TEN governance system, e.g. are unlawful. 
+* Submission of TIP on Snapshot with a link to the TEN governance forum. Only holders of TEN tokens can submit a TIP
+* Discussion on the TEN governance forum and the opportunity to vote over 14 days to gauge interest. To vote you must hold at least one TEN token for 30 days or more
+* A simple majority vote (more than 50%) against the proposal at this stage discourages progressing to level 2
+
+### Level 2: On-chain Voting Preparation
+This second level is the first step towards formalizing the TIP and preparing for the more meaningful vote at the next level.
+* Official submission via governance smart contracts on TEN
+* Requires a wallet address representing at least 1 TEN token held for at least 30 days
+* 3-day discussion period before voter snapshot and voting
+
+### Level 3: On-chain Vote
+At this third level those who are eligible to vote will do so. There is a minimum threshold of engagement so only genuinely relevant TIPs are progressed.
+* On-chain voting by participants of TEN's governance via Tally
+* A simple majority vote in favor (more than 50%) plus meeting a minimum threshold of engagement means the TIP will be moved on to level 4 voting. The minimum threshold of engagement is 5% of all TEN tokens in circulation
+* A majority vote against the TIP brings the lifecycle to an end. The original submitter is welcome to resubmit the TIP at Level 1 taking on board feedback and comments
+
+### Level 4: Acknowledge and Confirm
+This fourth level is a safety backstop and is particularly important in the early life of TEN. Consider this level to be the training wheels.
+* The TEN Governance Board are requested to acknowledge the voting outcome for the TIP
+* Confirmation moves the TIP to the next Level
+
+### Level 5: Reaction Period
+The fifth level recognizes not everyone can be satisfied all of the time therefore individuals have an opportunity to change how they engage with TEN.
+* Post-approval 3-day period in which members of the TEN ecosystem can react to the approved TIP by changing how they engage with TEN, for example, withdrawing assets on TEN or deploying changes to smart contracts on TEN.
+
+### Level 6: TEN to Ethereum Message
+The sixth level is an important step so the voting result can be immutably captured on Ethereum mainnet.
+* Sending an L2-to-L1 message indicating TIP approval, finalizing on Ethereum mainnet
+* A 12 hour period is ample time for the L2-to-L1 message to be finalized by the TEN validators
+
+### Level 7: Ethereum Finalization Period
+This level is a safety margin in case there is a transaction in process on Ethereum which would be detrimentally affected by the execution of the TIP.
+* 3-day period to finalize in-progress transactions on Ethereum mainnet before implementation
+
+### Level 8: TIP Implementation
+This is the final level where the TIP is fully executed and implemented. Only a future TIP will change the end result of the TIP.
+* Final execution of the TIP either on the Ethereum mainnet or via L1-to-L2 transactions
+
+## Additional Waiting Periods
+For breaking changes, additional waiting periods mean stakeholders and partners can prepare for the TIP's changes. These waiting periods give time for members of the ecosystem to react to the TIP and make any necessary changes or updates.
+
+## Conclusion
+The TIP process, spanning 8 levels, typically takes 40.5 days from start to finish. The levels have been designed to allow for thorough consideration, discussion, and thoughtful voting. This process aligns proposed changes with TEN's mission and values, allowing stakeholders to prepare for and adapt to new changes.
+
+
+
+

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -7,5 +7,4 @@
 
 .featureSvg {
   height: 264px;
-  width: 200px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,4 @@
   --ifm-color-primary-lightest: #7AA8F4;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+


### PR DESCRIPTION
How TEN is to be governed needs to be made available to read and linked to from Twitter and other websites. This is the first iteration of the governance documentation for the TEN Network Association.
Also made a change to the css to stop the images on the front page of docs.ten.xyz from being squashed